### PR TITLE
Change scale using Entity's Scale

### DIFF
--- a/font_renderer.js
+++ b/font_renderer.js
@@ -389,7 +389,8 @@ FontRenderer.prototype.calculateOffset = function () {
 FontRenderer.prototype.calculateScaling = function () {
     var canvas = this.app.graphicsDevice.canvas;
     var scale = canvas.offsetHeight / this.maxResHeight;
-    this.scaling.set(scale, scale);
+    var s = this.entity.getLocalScale();
+    this.scaling.set(scale * s.x, scale * s.y);
     return this.scaling;
 };
 


### PR DESCRIPTION
its really hard to change text scale by changing `maxResHeight`.  
Using Entity's Scale to change text size, it more more easy to control than using maxResHeight.

I checked my project to work it but no test code.